### PR TITLE
Fix: prevent Enemy from taking damage during immunity

### DIFF
--- a/classes/entities/Enemy.py
+++ b/classes/entities/Enemy.py
@@ -18,6 +18,8 @@ class Enemy(Creature):
     surface.blit(self.image, (self.x, self.y))
 
   def checkForDamage(self, weapon):
+    if self.immunity_count > 0:
+      return
     if self.hitbox.collides(weapon.hitbox):
       self.damage_direction = weapon.direction
       self.takeDamage(weapon.damage)


### PR DESCRIPTION
Checked the failing Enemy test and found it was due to no immunity check in checkForDamage in the Enemy class. I added this, and the test now passes.

Fixes #44 