### PR TITLE
fix: Change hitbox_offset_dimentions default keys to "x"/"y"

### DIFF
--- a/classes/entities/Creature.py
+++ b/classes/entities/Creature.py
@@ -12,7 +12,7 @@ class Creature:
     height = 50, 
     x = 0, 
     y = 0, 
-    hitbox_offset_dimentions = {"x-offset": 0, "y-offset": 0, "width": 0, "height": 0},
+    hitbox_offset_dimentions = {"x": 0, "y": 0, "width": 0, "height": 0},
     hitbox_visible = False,
     alive = True,
     health = 100,


### PR DESCRIPTION
Closes #81

This PR fixes a `KeyError` in `classes/entities/Creature.py` caused by an inconsistency between the default parameter keys in the `__init__` method and the keys used elsewhere in the class.

### Description of Bug

The `hitbox_offset_dimentions` parameter in `Creature.__init__` had default keys `"x-offset"` and `"y-offset"`.

```python
def __init__(
    self,
    spritePath,
    animationSpeed,
    width = 50,
    height = 50,
    x = 0,
    y = 0,
    hitbox_offset_dimentions = {"x-offset": 0, "y-offset": 0, "width": 0, "height": 0},  # Wrong keys
    hitbox_visible = False,
    alive = True,
    health = 100,
    display_health = True
):

# (lines 36-44):
self._hitbox = Hitbox(
    {
        "x": x + hitbox_offset_dimentions["x"],        # Expects "x", not "x-offset"
        "y": y + hitbox_offset_dimentions["y"],        # Expects "y", not "y-offset"
        "width": hitbox_offset_dimentions["width"],
        "height": hitbox_offset_dimentions["height"]
    },
    hitbox_visible
)

# (lines 326, 330):
def moveTo(self, x, y):
    self.x = x
    self.hitbox.x = self.x + self.hitbox_offset_dimentions["x"]       # Expects "x", not "x-offset"
    self.y = y
    self.hitbox.y = self.y + self.hitbox_offset_dimentions["y"]       # Expects "y", not "y-offset"
```

### Solution
```python
def __init__(
    self,
    spritePath,
    animationSpeed,
    width = 50,
    height = 50,
    x = 0,
    y = 0,
    hitbox_offset_dimentions = {"x": 0, "y": 0, "width": 0, "height": 0},
    hitbox_visible = False,
    alive = True,
    health = 100,
    display_health = True
):
```