### PR TITLE
Fix wall sliding stick behavior

### DIFF
--- a/docs/classes/entities/Creature.md
+++ b/docs/classes/entities/Creature.md
@@ -366,19 +366,20 @@ Prevents the creature from moving through screen borders by setting the appropri
 creature.handleBorderCollision(game_world, "Up")
 ```
 
-### `handleTileCollision(direction)`
+### `handleTileCollision(direction, tile)`
 
-Prevents the creature from moving through solid tiles by setting the appropriate directional speed multiplier to 0.
+Prevents the creature from moving through solid tiles by snapping their position to the nearest empty space in the direction of the collision and setting the appropriate directional speed multiplier to 0.
 
 **Parameters:**
 - `direction`: The direction of tile collision ("Up", "Down", "Left", or "Right")
+- `tile`: The tile object that the creature collides with.
 
 **Returns:**
 - `None`
 
 **Example:**
 ```python
-creature.handleTileCollision("Left")
+creature.handleTileCollision("Left", tile_037)
 ```
 
 ### `progress_death()`

--- a/src/classes/entities/Creature.py
+++ b/src/classes/entities/Creature.py
@@ -264,7 +264,7 @@ class Creature:
       for tile in world_map.current_screen.tiles:
         if tile.hitbox_active and self.hitbox.collides(tile.hitbox):
           collision_direction = self.hitbox.getReverseCollisionDirection(tile.hitbox)
-          self.handleTileCollision(collision_direction)
+          self.handleTileCollision(collision_direction, tile)
       
       if self.immunity_count > 0:
         self.immunity_count -= 1
@@ -343,14 +343,26 @@ class Creature:
     if direction == "Right":
       self.right_speed = 0
       
-  def handleTileCollision(self, direction):
+  def handleTileCollision(self, direction, tile):
+    EPS = 1e-6
     if direction == "Up":
+      self.hitbox.y = tile.hitbox.y + tile.hitbox.height - EPS
+      self.y = self.hitbox.y - self.hitbox_offset_dimentions["y"]
       self.up_speed = 0
-    if direction == "Down":
+
+    elif direction == "Down":
+      self.hitbox.y = tile.hitbox.y - self.hitbox.height + EPS
+      self.y = self.hitbox.y - self.hitbox_offset_dimentions["y"]
       self.down_speed = 0
-    if direction == "Left":
+
+    elif direction == "Left":
+      self.hitbox.x = tile.hitbox.x + tile.hitbox.width - EPS
+      self.x = self.hitbox.x - self.hitbox_offset_dimentions["x"]
       self.left_speed = 0
-    if direction == "Right":
+
+    elif direction == "Right":
+      self.hitbox.x = tile.hitbox.x - self.hitbox.width + EPS
+      self.x = self.hitbox.x - self.hitbox_offset_dimentions["x"]
       self.right_speed = 0
 
   def progress_death(self):


### PR DESCRIPTION
Fixes #7 

Creature could get stuck on a wall when walking parallel to it too closely.

Updated handleTileCollision to accept tile argument and snap Creature position outside of collision overlap before zeroing speed. Added epsilon (EPS) parameter to fine tune the snapping to account for floating point precision jitters.

Tested manually by walking along all 4 wall directions.
